### PR TITLE
Corrected Versioning Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Fetch latest version from tags and increment it based on pull request labels.
 Increments based on the given fragment.
 
 ### `major`
-0.1.6 -> 0.1.7
+0.1.6 -> 1.0.0
 
 ### `feature`
 0.1.6 -> 0.2.0
 
 ### `bug`
-0.1.6 -> 1.0.0
+0.1.6 -> 0.1.7
 
 If trigger on `pull_request`, will extract the hightest fragment from the assigned labels names.
 If triggered on `repository_dispatch`, a fragment can be specified in the `client_payload`


### PR DESCRIPTION
Fixed the versioning example so it matches the version type above it.